### PR TITLE
fixing ignores regex

### DIFF
--- a/bin/to-s3
+++ b/bin/to-s3
@@ -17,7 +17,7 @@ commander
   .usage('<files...> <bucket> [options]')
   .option('-p, --prefix <prefix>', 'Prefix files with path in bucket', '')
   .option('-a, --acl <acl>', 'The canned ACL to apply to the object. Possible values include: private | public-read | public-read-write | authenticated-read | bucket-owner-read | bucket-owner-full-control', 'private')
-  .option('-i, --ignore <ignore>', 'Ignore files and folders that match the given string(s)', '^.')
+  .option('-i, --ignore <ignore>', 'Ignore files and folders that match the given string(s)', '^\\.')
   .option('-q, --quiet', 'Quiet logs.')
   .option('-v, --verbose', 'Show notices')
   .parse(process.argv);


### PR DESCRIPTION
I had to change that regex string to make it work in my macbook. the dot was matching any character as I expected and not the .files as I suppose that mean to be.
