### PR TITLE
update (AWS credentials): Allow use of system file

### DIFF
--- a/bin/to-s3
+++ b/bin/to-s3
@@ -24,12 +24,13 @@ commander
   .parse(process.argv);
 
 /**
- * Check for AWS credentials
+ * Check for AWS credentials - warn if they don't exist
  */
 
 if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
-  error('Set AWS Access Key ID & AWS Secret Access Key as environment variables. See: http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html');
-  process.exit(1);
+  console.log('WARNING: No AWS Access Key ID & AWS Secret Access Key environment variables.');
+  console.log('         Relying on AWS credential file (e.g. on *nix systems: ~/.aws/credentials');
+  console.log('         See: http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html');
 }
 
 /**

--- a/bin/to-s3
+++ b/bin/to-s3
@@ -24,16 +24,6 @@ commander
   .parse(process.argv);
 
 /**
- * Check for AWS credentials - warn if they don't exist
- */
-
-if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
-  console.log('WARNING: No AWS Access Key ID & AWS Secret Access Key environment variables.');
-  console.log('         Relying on AWS credential file (e.g. on *nix systems: ~/.aws/credentials');
-  console.log('         See: http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html');
-}
-
-/**
  * Required data
  */
 


### PR DESCRIPTION
Allows the default behaviour if there are no credential env vars, of looking for credentials in the aws (user) credential file

https://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs

I have tested it with aws-sdk@2.1.14 and awsk-sdk@2.2.37 on OSX 10.11.3 node v4.6.2